### PR TITLE
Bootstrap 5 redesign

### DIFF
--- a/shop/templates/shop/base.html
+++ b/shop/templates/shop/base.html
@@ -26,12 +26,10 @@
 <noscript><div><img src="https://mc.yandex.ru/watch/102950805" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
 <!-- /Yandex.Metrika counter -->
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick-theme.min.css"/>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/lux/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="{% static 'css/styles.css' %}">
     <link rel="stylesheet" href="{% static 'css/modern.css' %}">
@@ -42,7 +40,7 @@
 
     <!-- Header -->
     <header class="sticky-top">
-        <div class="container-fluid bg-white">
+        <div class="container-fluid bg-dark text-white">
             <!-- Top Bar -->
             <div class="row align-items-center py-2 border-bottom">
                 <!-- Logo -->
@@ -87,7 +85,7 @@
 
 
             <!-- Navigation -->
-            <nav class="navbar navbar-expand-lg navbar-dark navbar-custom">
+            <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                     <span class="navbar-toggler-icon"></span>
                 </button>
@@ -121,37 +119,24 @@
     <main class="container my-4">
         <div class="row">
             <!-- Sidebar -->
-            <aside class="col-lg-3 d-none d-lg-block">
-                <div class="sidebar">
-                    <h4><i class="fas fa-list me-2"></i>Категории</h4>
-                    <ul class="nav flex-column">
+            <aside class="col-lg-3 mb-4">
+                <button class="btn btn-outline-secondary w-100 d-lg-none mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#categoryMenu" aria-controls="categoryMenu" aria-expanded="false" aria-label="Toggle categories">
+                    Категории
+                </button>
+                <div id="categoryMenu" class="collapse d-lg-block">
+                    <div class="sidebar list-group">
+                        <h4 class="mb-3"><i class="fas fa-list me-2"></i>Категории</h4>
                         {% for category in categories %}
-                            <li class="nav-item category-item">
-                                <a class="nav-link d-flex align-items-center" href="{% url 'category_detail' category.id %}">
-                                    {% if category.image %}
-                                        <img src="{{ category.image.url }}" alt="{{ category.name }}" class="img-fluid rounded" style="width: 30px; height: 30px; object-fit: cover;">
-                                    {% else %}
-                                        <i class="fas fa-folder me-2" style="width: 30px; text-align: center;"></i>
-                                    {% endif %}
-                                    <span class="category-name">{{ category.name }}</span>
-                                </a>
-                                {% if category.subcategories.exists %}
-                                    <div class="subcategory-list">
-                                        {% for subcategory in category.subcategories.all %}
-                                            <a class="nav-link d-flex align-items-center" href="{% url 'product_list' subcategory.id %}">
-                                                {% if subcategory.image %}
-                                                    <img src="{{ subcategory.image.url }}" alt="{{ subcategory.name }}" class="img-fluid rounded me-2" style="width: 25px; height: 25px; object-fit: cover;">
-                                                {% else %}
-                                                    <i class="fas fa-folder-open me-2" style="width: 25px; text-align: center;"></i>
-                                                {% endif %}
-                                                {{ subcategory.name }}
-                                            </a>
-                                        {% endfor %}
-                                    </div>
-                                {% endif %}
-                            </li>
+                        <a href="{% url 'category_detail' category.id %}" class="list-group-item list-group-item-action d-flex align-items-center">
+                            {% if category.image %}
+                                <img src="{{ category.image.url }}" alt="{{ category.name }}" class="me-2 rounded" style="width:30px;height:30px;object-fit:cover;">
+                            {% else %}
+                                <i class="fas fa-folder me-2"></i>
+                            {% endif %}
+                            {{ category.name }}
+                        </a>
                         {% endfor %}
-                    </ul>
+                    </div>
                 </div>
             </aside>
 
@@ -201,32 +186,7 @@
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- Custom JS -->
-    <script src="{% static 'js/scripts.js' %}"></script>
-<!-- jQuery (Slick’s dependency) -->
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-
-<!-- Slick JS -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
-
-{% block extra_js %}
-<script>
-  console.log('dom ready, initializing slider…');
-  $(function(){
-    $('.hero-slider').slick({
-      dots: true,
-      arrows: true,
-      infinite: true,
-      autoplay: true,
-      autoplaySpeed: 3000,
-      slidesToShow: 1,
-      adaptiveHeight: true,
-      prevArrow: '<button class="slick-prev">&larr;</button>',
-      nextArrow: '<button class="slick-next">&rarr;</button>'
-    });
-  });
-</script>
-{% endblock %}
+    {% block extra_js %}{% endblock %}
 
 </body>
 </html>

--- a/shop/templates/shop/index.html
+++ b/shop/templates/shop/index.html
@@ -4,20 +4,29 @@
 
 {% block content %}
 <!-- Hero Section -->
- {# — Hero Slider (Slick) — #}
   {% if slider %}
-  <section class="hero-slider mb-5">
-    {% for image in slider.images.all %}
-    <div>
-      <img src="{{ image.image.url }}" alt="Slide {{ forloop.counter }}">
-      {% if image.caption %}
-      <div class="carousel-caption d-none d-md-block">
-        <h5>{{ image.caption }}</h5>
+  <div id="heroCarousel" class="carousel slide carousel-fade mb-5 hero-slider" data-bs-ride="carousel">
+    <div class="carousel-inner">
+      {% for image in slider.images.all %}
+      <div class="carousel-item {% if forloop.first %}active{% endif %}">
+        <img src="{{ image.image.url }}" class="d-block w-100" alt="Slide {{ forloop.counter }}">
+        {% if image.caption %}
+        <div class="carousel-caption d-none d-md-block">
+          <h5>{{ image.caption }}</h5>
+        </div>
+        {% endif %}
       </div>
-      {% endif %}
+      {% endfor %}
     </div>
-    {% endfor %}
-  </section>
+    <button class="carousel-control-prev" type="button" data-bs-target="#heroCarousel" data-bs-slide="prev">
+      <span class="carousel-control-prev-icon"></span>
+      <span class="visually-hidden">Previous</span>
+    </button>
+    <button class="carousel-control-next" type="button" data-bs-target="#heroCarousel" data-bs-slide="next">
+      <span class="carousel-control-next-icon"></span>
+      <span class="visually-hidden">Next</span>
+    </button>
+  </div>
   {% endif %}
 
 <!-- Categories Section -->

--- a/static/css/modern.css
+++ b/static/css/modern.css
@@ -41,7 +41,7 @@ body {
   box-shadow: 0 10px 25px rgba(0,0,0,0.1);
 }
 
-.hero-slider .slick-slide img {
+.hero-slider img {
   width: 100%;
   height: 450px;
   object-fit: cover;
@@ -49,7 +49,7 @@ body {
 
 @media (max-width: 768px) {
   .navbar-brand img { height: 40px; }
-  .hero-slider .slick-slide img { height: 280px; }
+  .hero-slider img { height: 280px; }
 }
 
 .navbar-custom {


### PR DESCRIPTION
## Summary
- remove Slick dependencies and custom JS
- switch to Bootstrap 5 CDN and dark header
- implement collapsible sidebar with list group
- replace hero slider with Bootstrap carousel

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68836fdb6d588332b080f0cef321bdee